### PR TITLE
fix: exit code doesn't return 1 when some vulnerabilities have been detected.

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,10 +40,7 @@ func main() {
 			log.Fatalf("Application interrupted [%v]", s)
 		})
 
-		result := scan(scannerConfig{*imageName, whitelist, *clair, *ip, *reportFile})
-		if len(result) > 0 {
-			os.Exit(1)
-		}
+		scan(scannerConfig{*imageName, whitelist, *clair, *ip, *reportFile})
 	}
 	app.Run(os.Args)
 }


### PR DESCRIPTION
The main goal of this tool is to return a list of vulnerabilities. This list might be empty or not.
Non-zero code indicates an error. Please: https://golang.org/pkg/os/#Exit
Hence, clair-scanner shouldn't return 1 when some vulnerabilities have been detected.