### PR TITLE
vulnerabilities: adding details

### DIFF
--- a/clair.go
+++ b/clair.go
@@ -16,9 +16,14 @@ const (
 )
 
 type vulnerabilityInfo struct {
-	Vulnerability string `json:"vulnerability"`
-	Namespace     string `json:"namespace"`
-	Severity      string `json:"severity"`
+	FeatureName    string `json:"featurename"`
+	FeatureVersion string `json:"featureversion"`
+	Vulnerability  string `json:"vulnerability"`
+	Namespace      string `json:"namespace"`
+	Description    string `json:"description"`
+	Link           string `json:"link"`
+	Severity       string `json:"severity"`
+	FixedBy        string `json:"fixedby"`
 }
 
 // analyzeLayer tells Clair which layers to analyze
@@ -82,7 +87,7 @@ func getVulnerabilities(clairURL string, layerIds []string) []vulnerabilityInfo 
 	for _, feature := range rawVulnerabilities.Features {
 		if len(feature.Vulnerabilities) > 0 {
 			for _, vulnerability := range feature.Vulnerabilities {
-				vulnerability := vulnerabilityInfo{vulnerability.Name, vulnerability.NamespaceName, vulnerability.Severity}
+				vulnerability := vulnerabilityInfo{feature.Name, feature.Version, vulnerability.Name, vulnerability.NamespaceName, vulnerability.Description, vulnerability.Link, vulnerability.Severity, vulnerability.FixedBy}
 				vulnerabilities = append(vulnerabilities, vulnerability)
 			}
 		}


### PR DESCRIPTION
Understanding the vulnerabilities wasn't easy and convenient since some details were missing.
These additional details help to determine the nature of the vulnerability discovered and its security implications.

Here is an example:
{
            "featurename": "curl",
            "featureversion": "7.38.0-4+deb8u5",
            "vulnerability": "CVE-2017-1000100",
            "namespace": "debian:8",
            "description": "When doing a TFTP transfer and curl/libcurl is given a URL that contains a very long file name (longer than about 515 bytes), the file name is truncated to fit within the buffer boundaries, but the buffer size is still wrongly updated to use the untruncated length. This too large value is then used in the sendto() call, making curl attempt to send more data than what is actually put into the buffer. The endto() function will then read beyond the end of the heap based buffer. A malicious HTTP(S) server could redirect a vulnerable libcurl-using client to a crafted TFTP URL (if the client hasn't restricted which protocols it allows redirects to) and trick it to send private memory contents to a remote server over UDP. Limit curl's redirect protocols with --proto-redir and libcurl's with CURLOPT_REDIR_PROTOCOLS.",
            "link": "https://security-tracker.debian.org/tracker/CVE-2017-1000100",
            "severity": "Medium",
            "fixedby": "7.38.0-4+deb8u6"
        }