### PR TITLE
Fix spelling in json report

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -14,7 +14,7 @@ type vulnerabilitiesWhitelist struct {
 
 type vulnerabilityReport struct {
 	Image           string              `json:"image"`
-	Unaproved       []string            `json:"unaproved"`
+	Unaproved       []string            `json:"unapproved"`
 	Vulnerabilities []vulnerabilityInfo `json:"vulnerabilities"`
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -14,7 +14,7 @@ type vulnerabilitiesWhitelist struct {
 
 type vulnerabilityReport struct {
 	Image           string              `json:"image"`
-	Unaproved       []string            `json:"unapproved"`
+	Unapproved       []string           `json:"unapproved"`
 	Vulnerabilities []vulnerabilityInfo `json:"vulnerabilities"`
 }
 
@@ -101,7 +101,7 @@ func printReport(imageName string, vulnerabilities []vulnerabilityInfo, unapprov
 		report := &vulnerabilityReport{
 			Image:           imageName,
 			Vulnerabilities: vulnerabilities,
-			Unaproved:       unapproved,
+			Unapproved:       unapproved,
 		}
 		reportToFile(report, file)
 	}


### PR DESCRIPTION
`unaproved` -> `unapproved`. 

It took me a while to realize why my code with `response['unapproved']` returned nothing. 