### PR TITLE
Detailed reporting and threshold-based CVE whitelisting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -80,6 +80,12 @@
   version = "v1.1"
 
 [[projects]]
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
+  version = "v0.0.2"
+
+[[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
@@ -90,6 +96,12 @@
   name = "github.com/mbndr/logo"
   packages = ["."]
   revision = "2cf79af92583dac1e32304d4eb833e8be68aa1e7"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/olekukonko/tablewriter"
+  packages = ["."]
+  revision = "96aac992fc8b1a4c83841a6c3e7178d20d989625"
 
 [[projects]]
   name = "github.com/pborman/uuid"
@@ -172,6 +184,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8675c78bfe80feb5da58258a95753a735ca81b8fa304648e7fa1994db3ad1a77"
+  inputs-digest = "197187947850b0ee9e0264ef2d4a6c150c29dc51f85040947ffbf50e3daf3c3b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,3 +13,6 @@
 
 [[constraint]]
   name = "github.com/mbndr/logo"
+
+[[constraint]]
+  name = "github.com/olekukonko/tablewriter"

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,17 @@ ensure:
 build:
 	CGO_ENABLED=0 go build
 
-docker: 
+docker:
 	@cd docker && \
 		docker build -t golang-cross-compile .
 
 cross: docker
 	docker run -ti --rm -e CGO_ENABLED=0 -v $(CURDIR):/gopath/src/clair-scanner -w /gopath/src/clair-scanner golang-cross-compile gox -osarch="darwin/amd64 darwin/386 linux/amd64 linux/386 windows/amd64 windows/386" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
-clean: 
+clean:
 	rm -rf dist
 
-rmdocker: 
+rmdocker:
 	-docker kill clair
 	-docker kill db
 	-docker rm clair
@@ -30,7 +30,6 @@ rmdocker:
 test:
 	go test
 
-
 pull:
 	docker pull alpine:3.5
 
@@ -38,7 +37,7 @@ dbosx:
 	docker run -p 5432:5432 -d --name db arminc/clair-db:$(shell date -v-1d +%Y-%m-%d)
 	@sleep 5
 
-db: 
+db:
 	docker run -p 5432:5432 -d --name db arminc/clair-db:$(shell date -d "-1 day" +%Y-%m-%d)
 	@sleep 5
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ Arguments:
 
 Options:
   -w, --whitelist=""                    Path to the whitelist file
+  -t, --threshold="Unknown"             CVE severity threshold. Valid values; 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'
   -c, --clair="http://127.0.0.1:6060"   Clair URL
   --ip="localhost"                      IP address where clair-scanner is running on
   -l, --log=""                          Log to a file
+  --all, --reportAll=true               Display all vulnerabilities, even if they are approved
   -r, --report=""                       Report output file, as JSON
 ```
 

--- a/example-whitelist.yaml
+++ b/example-whitelist.yaml
@@ -4,6 +4,6 @@ generalwhitelist:
 images:
   ubuntu:
     CVE-2017-5230: Java
-    CVE-2017-5230: XSX  
+    CVE-2017-5230: XSX
   alpine:
     CVE-2017-3261: SE

--- a/integration_test.go
+++ b/integration_test.go
@@ -20,7 +20,15 @@ func TestMain(m *testing.M) {
 
 func TestDebian(t *testing.T) {
 	initializeLogger("")
-	unapproved := scan(scannerConfig{"debian:wheezy", vulnerabilitiesWhitelist{}, "http://127.0.0.1:6060", *ip, ""})
+	unapproved := scan(scannerConfig{
+		"debian:wheezy",
+		vulnerabilitiesWhitelist{},
+		"http://127.0.0.1:6060",
+		*ip,
+		"",
+		"Unknown",
+		true,
+	})
 	if len(unapproved) == 0 {
 		t.Errorf("No vulnerabilities, expecting some")
 	}

--- a/reporter.go
+++ b/reporter.go
@@ -30,12 +30,6 @@ func sortBySeverity(vulnerabilities []vulnerabilityInfo) {
 	})
 }
 
-// func sortByStatus(vulnerabilities []vulnerabilityInfo, unapproved []string) {}
-
-func formatSeverity(severity string) string {
-	return fmt.Sprintf(ErrorColor, severity)
-}
-
 func formatStatus(status string) string {
 	if status == "Approved" {
 		return fmt.Sprintf(NoticeColor, status)
@@ -54,7 +48,7 @@ func formatTableData(vulnerabilities []vulnerabilityInfo, unapproved []string) [
 		}
 		formatted[i] = []string{
 			formatStatus(status),
-			formatSeverity(vulnerability.Severity) + " " + vulnerability.Vulnerability,
+			vulnerability.Severity + " " + vulnerability.Vulnerability,
 			vulnerability.FeatureName,
 			vulnerability.FeatureVersion,
 			vulnerability.Description + "\n\n" + vulnerability.Link,
@@ -94,15 +88,19 @@ func filterApproved(vulnerabilities []vulnerabilityInfo, unapproved []string, re
 func reportToConsole(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, reportAll bool) {
 	if len(vulnerabilities) > 0 {
 		logger.Warnf("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
-		if len(unapproved) > 0 {
-			logger.Errorf("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
-		} else {
-			logger.Infof("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
-		}
+
 		vulnerabilities = filterApproved(vulnerabilities, unapproved, reportAll)
 		sortBySeverity(vulnerabilities)
-		// sortByStatus(vulnerabilities)
-		printTable(vulnerabilities, unapproved)
+
+		if len(unapproved) > 0 {
+			logger.Errorf("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
+			printTable(vulnerabilities, unapproved)
+		} else {
+			logger.Infof("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
+			if reportAll {
+				printTable(vulnerabilities, unapproved)
+			}
+		}
 	} else {
 		logger.Infof("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
 	}

--- a/reporter.go
+++ b/reporter.go
@@ -15,15 +15,6 @@ type vulnerabilityReport struct {
 	Vulnerabilities []vulnerabilityInfo `json:"vulnerabilities"`
 }
 
-type ReportTableRow struct {
-	Severity    string
-	Feature     string
-	Details     string
-	Description string
-}
-
-type ReportTableData [][]ReportTableRow
-
 func sortBySeverity(vulnerabilities []vulnerabilityInfo) {
 	sort.Slice(vulnerabilities, func(i, j int) bool {
 		return SeverityMap[vulnerabilities[i].Severity] < SeverityMap[vulnerabilities[j].Severity]
@@ -96,13 +87,13 @@ func reportToConsole(imageName string, vulnerabilities []vulnerabilityInfo, unap
 			logger.Errorf("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
 			printTable(vulnerabilities, unapproved)
 		} else {
-			logger.Infof("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
+			logger.Infof("Image [%s] contains NO unapproved vulnerabilities", imageName)
 			if reportAll {
 				printTable(vulnerabilities, unapproved)
 			}
 		}
 	} else {
-		logger.Infof("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
+		logger.Infof("Image [%s] contains NO unapproved vulnerabilities", imageName)
 	}
 }
 

--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"io/ioutil"
+	"os"
+	"sort"
+)
+
+type vulnerabilityReport struct {
+	Image           string              `json:"image"`
+	Unapproved      []string            `json:"unapproved"`
+	Vulnerabilities []vulnerabilityInfo `json:"vulnerabilities"`
+}
+
+type ReportTableRow struct {
+	Severity    string
+	Feature     string
+	Details     string
+	Description string
+}
+
+type ReportTableData [][]ReportTableRow
+
+func sortBySeverity(vulnerabilities []vulnerabilityInfo) {
+	sort.Slice(vulnerabilities, func(i, j int) bool {
+		return SeverityMap[vulnerabilities[i].Severity] < SeverityMap[vulnerabilities[j].Severity]
+	})
+}
+
+// func sortByStatus(vulnerabilities []vulnerabilityInfo, unapproved []string) {}
+
+func formatSeverity(severity string) string {
+	return fmt.Sprintf(ErrorColor, severity)
+}
+
+func formatStatus(status string) string {
+	if status == "Approved" {
+		return fmt.Sprintf(NoticeColor, status)
+	}
+	return fmt.Sprintf(ErrorColor, status)
+}
+
+func formatTableData(vulnerabilities []vulnerabilityInfo, unapproved []string) [][]string {
+	formatted := make([][]string, len(vulnerabilities))
+	for i, vulnerability := range vulnerabilities {
+		status := "Approved"
+		for _, u := range unapproved {
+			if vulnerability.Vulnerability == u {
+				status = "Unapproved"
+			}
+		}
+		formatted[i] = []string{
+			formatStatus(status),
+			formatSeverity(vulnerability.Severity) + " " + vulnerability.Vulnerability,
+			vulnerability.FeatureName,
+			vulnerability.FeatureVersion,
+			vulnerability.Description + "\n\n" + vulnerability.Link,
+		}
+	}
+	return formatted
+}
+
+func printTable(vulnerabilities []vulnerabilityInfo, unapproved []string) {
+	header := []string{"Status", "CVE Severity", "Package Name", "Package Version", "CVE Description"}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(header)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetRowSeparator("-")
+	table.SetRowLine(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.AppendBulk(formatTableData(vulnerabilities, unapproved))
+	table.Render()
+}
+
+func filterApproved(vulnerabilities []vulnerabilityInfo, unapproved []string, reportAll bool) []vulnerabilityInfo {
+	if reportAll {
+		return vulnerabilities
+	}
+
+	vulns := make([]vulnerabilityInfo, 0)
+	for _, vuln := range vulnerabilities {
+		for _, u := range unapproved {
+			if vuln.Vulnerability == u {
+				vulns = append(vulns, vuln)
+			}
+		}
+	}
+	return vulns
+}
+
+func reportToConsole(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, reportAll bool) {
+	if len(vulnerabilities) > 0 {
+		logger.Warnf("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
+		if len(unapproved) > 0 {
+			logger.Errorf("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
+		} else {
+			logger.Infof("Image [%s] contains %d unapproved vulnerabilities", imageName, len(unapproved))
+		}
+		vulnerabilities = filterApproved(vulnerabilities, unapproved, reportAll)
+		sortBySeverity(vulnerabilities)
+		// sortByStatus(vulnerabilities)
+		printTable(vulnerabilities, unapproved)
+	} else {
+		logger.Infof("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
+	}
+}
+
+// reportToFile writes the report to file
+func reportToFile(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, file string) {
+	if file == "" {
+		return
+	}
+	report := &vulnerabilityReport{
+		Image:           imageName,
+		Vulnerabilities: vulnerabilities,
+		Unapproved:      unapproved,
+	}
+	reportJSON, err := json.MarshalIndent(report, "", "    ")
+	if err != nil {
+		logger.Fatalf("Could not create a report: report is not proper JSON %v", err)
+	}
+	if err = ioutil.WriteFile(file, reportJSON, 0644); err != nil {
+		logger.Fatalf("Could not create a report: could not write to file %v", err)
+	}
+}

--- a/scanner.go
+++ b/scanner.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -12,20 +10,26 @@ type vulnerabilitiesWhitelist struct {
 	Images           map[string]map[string]string // image name with [key: CVE and value: CVE description]
 }
 
-type vulnerabilityReport struct {
-	Image           string              `json:"image"`
-	Unapproved       []string           `json:"unapproved"`
-	Vulnerabilities []vulnerabilityInfo `json:"vulnerabilities"`
-}
-
 const tmpPrefix = "clair-scanner-"
 
 type scannerConfig struct {
-	imageName  string
-	whitelist  vulnerabilitiesWhitelist
-	clairURL   string
-	scannerIP  string
-	reportFile string
+	imageName          string
+	whitelist          vulnerabilitiesWhitelist
+	clairURL           string
+	scannerIP          string
+	reportFile         string
+	whitelistThreshold string
+	reportAll          bool
+}
+
+var SeverityMap = map[string]int{
+	"Defcon1":    1,
+	"Critical":   2,
+	"High":       3,
+	"Medium":     4,
+	"Low":        5,
+	"Negligible": 6,
+	"Unknown":    7,
 }
 
 // scan orchestrates the scanning process of an image
@@ -46,24 +50,37 @@ func scan(config scannerConfig) []string {
 	vulnerabilities := getVulnerabilities(config.clairURL, layerIds)
 
 	//Check vulnerabilities against whitelist and report
-	unapproved := checkForUnapprovedVulnerabilities(config.imageName, vulnerabilities, config.whitelist)
-	printReport(config.imageName, vulnerabilities, unapproved, config.reportFile)
+	unapproved := checkForUnapprovedVulnerabilities(config.imageName, vulnerabilities, config.whitelist, config.whitelistThreshold)
+
+	// Report vulnerabilities
+	reportToConsole(config.imageName, vulnerabilities, unapproved, config.reportAll)
+	reportToFile(config.imageName, vulnerabilities, unapproved, config.reportFile)
 
 	return unapproved
 }
 
 // checkForUnapprovedVulnerabilities checks if the found vulnerabilities are approved or not in the whitelist
-func checkForUnapprovedVulnerabilities(imageName string, vulnerabilities []vulnerabilityInfo, whitelist vulnerabilitiesWhitelist) []string {
+func checkForUnapprovedVulnerabilities(imageName string, vulnerabilities []vulnerabilityInfo, whitelist vulnerabilitiesWhitelist, whitelistThreshold string) []string {
 	unapproved := []string{}
 	imageVulnerabilities := getImageVulnerabilities(imageName, whitelist.Images)
 
 	for i := 0; i < len(vulnerabilities); i++ {
 		vulnerability := vulnerabilities[i].Vulnerability
+		severity := vulnerabilities[i].Severity
 		vulnerable := true
 
-		//Check if the vulnerability exists in the GeneralWhitelist
-		if _, exists := whitelist.GeneralWhitelist[vulnerability]; exists {
+		// logger.Infof("%s %s %s %s", severity, SeverityMap[severity], whitelistThreshold, SeverityMap[whitelistThreshold])
+
+		//Check if the vulnerability has a severity less than our threshold severity
+		if SeverityMap[severity] > SeverityMap[whitelistThreshold] {
 			vulnerable = false
+		}
+
+		//Check if the vulnerability exists in the GeneralWhitelist
+		if vulnerable {
+			if _, exists := whitelist.GeneralWhitelist[vulnerability]; exists {
+				vulnerable = false
+			}
 		}
 
 		//If not in GeneralWhitelist check if the vulnerability exists in the imageVulnerabilities
@@ -87,33 +104,4 @@ func getImageVulnerabilities(imageName string, whitelistImageVulnerabilities map
 		imageVulnerabilities = val
 	}
 	return imageVulnerabilities
-}
-
-// printReport shows the unapproved vulnerabilities and writes a report to file
-func printReport(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, file string) {
-	if len(unapproved) > 0 {
-		logger.Infof("Unapproved vulnerabilities [%s]", unapproved)
-	} else {
-		logger.Infof("Image [%s] not vulnerable", imageName)
-	}
-
-	if file != "" {
-		report := &vulnerabilityReport{
-			Image:           imageName,
-			Vulnerabilities: vulnerabilities,
-			Unapproved:       unapproved,
-		}
-		reportToFile(report, file)
-	}
-}
-
-// reportToFile writes the report to file
-func reportToFile(report *vulnerabilityReport, file string) {
-	reportJSON, err := json.MarshalIndent(report, "", "    ")
-	if err != nil {
-		logger.Fatalf("Could not create a report: report is not proper JSON %v", err)
-	}
-	if err = ioutil.WriteFile(file, reportJSON, 0644); err != nil {
-		logger.Fatalf("Could not create a report: could not write to file %v", err)
-	}
 }

--- a/scanner.go
+++ b/scanner.go
@@ -22,16 +22,6 @@ type scannerConfig struct {
 	reportAll          bool
 }
 
-var SeverityMap = map[string]int{
-	"Defcon1":    1,
-	"Critical":   2,
-	"High":       3,
-	"Medium":     4,
-	"Low":        5,
-	"Negligible": 6,
-	"Unknown":    7,
-}
-
 // scan orchestrates the scanning process of an image
 func scan(config scannerConfig) []string {
 	//Create a temporary folder where the docker image layers are going to be stored
@@ -68,8 +58,6 @@ func checkForUnapprovedVulnerabilities(imageName string, vulnerabilities []vulne
 		vulnerability := vulnerabilities[i].Vulnerability
 		severity := vulnerabilities[i].Severity
 		vulnerable := true
-
-		// logger.Infof("%s %s %s %s", severity, SeverityMap[severity], whitelistThreshold, SeverityMap[whitelistThreshold])
 
 		//Check if the vulnerability has a severity less than our threshold severity
 		if SeverityMap[severity] > SeverityMap[whitelistThreshold] {

--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,14 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	InfoColor    = "\033[1;34m%s\033[0m"
+	NoticeColor  = "\033[1;36m%s\033[0m"
+	WarningColor = "\033[1;33m%s\033[0m"
+	ErrorColor   = "\033[1;31m%s\033[0m"
+	DebugColor   = "\033[0;36m%s\033[0m"
+)
+
 // listenForSignal listens for interactions and executes the desired code when it happens
 func listenForSignal(fn func(os.Signal)) {
 	signalChannel := make(chan os.Signal, 0)
@@ -77,4 +85,27 @@ func parseWhitelistFile(whitelistFile string) vulnerabilitiesWhitelist {
 		logger.Fatalf("Could not parse whitelist file, could not unmarshal %v", err)
 	}
 	return whitelistTmp
+}
+
+// Validate that the given CVE severity threshold is a valid severity
+func validateThreshold(threshold string) {
+	valid := false
+	for severity := range SeverityMap {
+		if threshold == severity {
+			valid = true
+		}
+	}
+	if !valid {
+		logger.Fatalf("Invalid CVE severity threshold %s given", threshold)
+	}
+}
+
+func Filter(vs []string, f func(string) bool) []string {
+	vsf := make([]string, 0)
+	for _, v := range vs {
+		if f(v) {
+			vsf = append(vsf, v)
+		}
+	}
+	return vsf
 }

--- a/utils.go
+++ b/utils.go
@@ -20,6 +20,17 @@ const (
 	DebugColor   = "\033[0;36m%s\033[0m"
 )
 
+// Exported var used as mapping on CVE severity name to implied ranking
+var SeverityMap = map[string]int{
+	"Defcon1":    1,
+	"Critical":   2,
+	"High":       3,
+	"Medium":     4,
+	"Low":        5,
+	"Negligible": 6,
+	"Unknown":    7,
+}
+
 // listenForSignal listens for interactions and executes the desired code when it happens
 func listenForSignal(fn func(os.Signal)) {
 	signalChannel := make(chan os.Signal, 0)
@@ -89,23 +100,10 @@ func parseWhitelistFile(whitelistFile string) vulnerabilitiesWhitelist {
 
 // Validate that the given CVE severity threshold is a valid severity
 func validateThreshold(threshold string) {
-	valid := false
 	for severity := range SeverityMap {
 		if threshold == severity {
-			valid = true
+			return
 		}
 	}
-	if !valid {
-		logger.Fatalf("Invalid CVE severity threshold %s given", threshold)
-	}
-}
-
-func Filter(vs []string, f func(string) bool) []string {
-	vsf := make([]string, 0)
-	for _, v := range vs {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
+	logger.Fatalf("Invalid CVE severity threshold %s given", threshold)
 }


### PR DESCRIPTION
> This is still a bit of a work in progress, but I wanted to post it up for feedback, and because I’m not a Golang-er by trade, so I’m sure there is going to be alterations required. :)

This PR enhances the post-analysis reporting to use a detailed table (see screenshot), and also slightly tweaks the approval mechanism to allow for threshold based whitelisting (i.e; can now throw errors for non-whitelisted vulnerabilities that are above a given CVE severity). It also allows for filtering the report that is generated to only show unapproved vulnerabilities, which is handy given that the table reporter is necessarily more verbose.

To accomplish this some additions were made to the CLI interface;
- `--threshold=<string: Unknown>`
    - Sets the severity threshold at which unapproved vulnerabilities should be considered errors. Can be set to any of the CVE severity labels. E.g `--threshold=High` would mean that vulnerabilities that are `High`, `Critical`, or `Defcon1` would be counted as errors, `Medium` would not.

- `--reportAll=<bool: false>`
    - Allows for filtering of the console report to only show unapproved vulnerabilities, or show all.

<img width="1166" alt="screen shot 2018-01-06 at 2 42 20 pm" src="https://user-images.githubusercontent.com/18076/34636913-45c10f40-f2ff-11e7-8340-75a80144015f.png">
