### PR TITLE
Debian wheezy is not supported any more, using jessie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ db:
 	@sleep 5
 
 clair:
-	docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.6
+	docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:latest
 	@sleep 5
 
 integration: pull db clair

--- a/Makefile
+++ b/Makefile
@@ -33,19 +33,15 @@ test:
 pull:
 	docker pull alpine:3.5
 
-dbosx:
-	docker run -p 5432:5432 -d --name db arminc/clair-db:$(shell date -v-1d +%Y-%m-%d)
-	@sleep 5
-
 db:
-	docker run -p 5432:5432 -d --name db arminc/clair-db:$(shell date -d "-1 day" +%Y-%m-%d)
+	docker run -p 5432:5432 -d --name db arminc/clair-db:latest
 	@sleep 5
 
 clair:
 	docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.6
 	@sleep 5
 
-integration: pull dbosx clair
+integration: pull db clair
 	go test -v -covermode=count -coverprofile=coverage.out -ip $(shell ipconfig getifaddr en0) -tags integration
 
 integrationlinux: pull db clair

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          curl \

--- a/integration_test.go
+++ b/integration_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 func TestDebian(t *testing.T) {
 	initializeLogger("")
 	unapproved := scan(scannerConfig{
-		"debian:wheezy",
+		"debian:jessie",
 		vulnerabilitiesWhitelist{},
 		"http://127.0.0.1:6060",
 		*ip,


### PR DESCRIPTION
Debian wheezy is not supported any more, using jessie.
Use latest clair-db incase clair-db is failing because vulnerabilities can't be fetched 