### PR TITLE
Add support to quiet ASCII table output

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 		logFile            = app.StringOpt("l log", "", "Log to a file")
 		reportAll          = app.BoolOpt("all reportAll", true, "Display all vulnerabilities, even if they are approved")
 		reportFile         = app.StringOpt("r report", "", "Report output file, as JSON")
+		quiet              = app.BoolOpt("q quiet", false, "Quiets ASCII table output")
 		imageName          = app.StringArg("IMAGE", "", "Name of the Docker image to scan")
 		exitWhenNoFeatures = app.BoolOpt("exit-when-no-features", false, "Exit with status code 5 when no features are found for a particular image")
 	)
@@ -52,6 +53,7 @@ func main() {
 			*reportFile,
 			*whitelistThreshold,
 			*reportAll,
+			*quiet,
 			*exitWhenNoFeatures,
 		})
 		if result == nil {

--- a/reporter.go
+++ b/reporter.go
@@ -76,7 +76,11 @@ func filterApproved(vulnerabilities []vulnerabilityInfo, unapproved []string, re
 	return vulns
 }
 
-func reportToConsole(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, reportAll bool) {
+func reportToConsole(imageName string, vulnerabilities []vulnerabilityInfo, unapproved []string, reportAll bool, quiet bool) {
+	if quiet {
+		return
+	}
+
 	if len(vulnerabilities) > 0 {
 		logger.Warnf("Image [%s] contains %d total vulnerabilities", imageName, len(vulnerabilities))
 

--- a/scanner.go
+++ b/scanner.go
@@ -20,6 +20,7 @@ type scannerConfig struct {
 	reportFile         string
 	whitelistThreshold string
 	reportAll          bool
+	quiet              bool
 	exitWhenNoFeatures bool
 }
 
@@ -48,7 +49,7 @@ func scan(config scannerConfig) []string {
 	unapproved := checkForUnapprovedVulnerabilities(config.imageName, vulnerabilities, config.whitelist, config.whitelistThreshold)
 
 	// Report vulnerabilities
-	reportToConsole(config.imageName, vulnerabilities, unapproved, config.reportAll)
+	reportToConsole(config.imageName, vulnerabilities, unapproved, config.reportAll, config.quiet)
 	reportToFile(config.imageName, vulnerabilities, unapproved, config.reportFile)
 
 	return unapproved


### PR DESCRIPTION
we are looking to use this in CI build, but would rather not have ascii tables extending the length of output when json will do perfectly