### PR TITLE
Should use empty TODO context instead of nil. Fixes nil pointer dereference panic

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"strings"
 )
@@ -35,14 +36,14 @@ func scan(config scannerConfig) []string {
 
 	//Start a server that can serve Docker image layers to Clair
 	server := httpFileServer(tmpPath)
-	defer server.Shutdown(nil)
+	defer server.Shutdown(context.TODO())
 
 	//Analyze the layers
 	analyzeLayers(layerIds, config.clairURL, config.scannerIP)
 	vulnerabilities := getVulnerabilities(config, layerIds)
 
 	if vulnerabilities == nil {
-		return nil; // exit when no features
+		return nil // exit when no features
 	}
 
 	//Check vulnerabilities against whitelist and report


### PR DESCRIPTION
Stacktrace before the fix below

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x63b501]

goroutine 1 [running]:
github.com/jawher/mow%2ecli.(*step).run(0xc0003a4510, {0x73ac40, 0xa38090})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:28 +0xa5
github.com/jawher/mow%2ecli.(*step).run(0xc0003a4720, {0x73ac40, 0xa38090})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:20 +0x8c
github.com/jawher/mow%2ecli.(*step).callDo.func1()
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:41 +0x5a
panic({0x73ac40, 0xa38090})
        /usr/lib/go/src/runtime/panic.go:1038 +0x215
net/http.(*Server).Shutdown(0xc00042a620, {0x0, 0x0})
        /usr/lib/go/src/net/http/server.go:2738 +0x201
main.scan({{0x7fff41ed1187, 0xa}, {0x0, 0x0}, {0x7a327a, 0x15}, {0x7fff41ed1177, 0xf}, {0x0, 0x0}, ...})
        /home/klim/tmp/clair-scanner/scanner.go:55 +0x383
main.main.func2()
        /home/klim/tmp/clair-scanner/main.go:48 +0x238
github.com/jawher/mow%2ecli.(*step).callDo(0xc0003a46f0, {0x0, 0x0})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:44 +0x77
github.com/jawher/mow%2ecli.(*step).run(0xc0003a4750, {0x0, 0x0})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:16 +0x31
github.com/jawher/mow%2ecli.(*step).run(0xc0003a46f0, {0x0, 0x0})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:20 +0x8c
github.com/jawher/mow%2ecli.(*step).run(0xc0002dfd90, {0x0, 0x0})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/flow.go:20 +0x8c
github.com/jawher/mow%2ecli.(*Cmd).parse(0xc000268b00, {0xc00001e0d0, 0x30, 0xa47260}, 0xc0003a4510, 0xc0002dfd90, 0xc0003a4510)
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/commands.go:443 +0x4af
github.com/jawher/mow%2ecli.(*Cli).parse(0xc000268b00, {0xc00001e0d0, 0x50, 0xa47260}, 0xc00033a6e0, 0x0, 0x0)
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/cli.go:73 +0x9f
github.com/jawher/mow%2ecli.(*Cli).Run(0xc0002dfe80, {0xc00001e0c0, 0x4, 0x4})
        /home/klim/workspace/go/pkg/mod/github.com/jawher/mow.cli@v1.0.2/cli.go:102 +0xe5
main.main()
        /home/klim/tmp/clair-scanner/main.go:65 +0x8e7
```