### PR TITLE
Convert Docker 24.1.x+ image export from OCI format to legacy format.

### DIFF
--- a/clair.go
+++ b/clair.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/coreos/clair/api/v1"
+	v1 "github.com/coreos/clair/api/v1"
 )
 
 const (
@@ -28,15 +28,21 @@ type vulnerabilityInfo struct {
 
 // analyzeLayer tells Clair which layers to analyze
 func analyzeLayers(layerIds []string, clairURL string, scannerIP string) {
+	var layerPath string
 	tmpPath := "http://" + scannerIP + ":" + httpPort
 
 	for i := 0; i < len(layerIds); i++ {
+		if legacy {
+			layerPath = tmpPath + "/" + layerIds[i] + "/layer.tar"
+		} else {
+			layerPath = tmpPath + "/" + layerIds[i]
+		}
 		logger.Infof("Analyzing %s", layerIds[i])
 
 		if i > 0 {
-			analyzeLayer(clairURL, tmpPath+"/"+layerIds[i]+"/layer.tar", layerIds[i], layerIds[i-1])
+			analyzeLayer(clairURL, layerPath, layerIds[i], layerIds[i-1])
 		} else {
-			analyzeLayer(clairURL, tmpPath+"/"+layerIds[i]+"/layer.tar", layerIds[i], "")
+			analyzeLayer(clairURL, layerPath, layerIds[i], "")
 		}
 	}
 }

--- a/scanner.go
+++ b/scanner.go
@@ -13,6 +13,8 @@ type vulnerabilitiesWhitelist struct {
 
 const tmpPrefix = "clair-scanner-"
 
+var legacy = false
+
 type scannerConfig struct {
 	imageName          string
 	whitelist          vulnerabilitiesWhitelist

--- a/server.go
+++ b/server.go
@@ -9,10 +9,20 @@ const (
 	httpPort = "9279"
 )
 
+type StatusRespWr struct {
+	http.ResponseWriter // We embed http.ResponseWriter
+	status              int
+}
+
+func (w *StatusRespWr) WriteHeader(status int) {
+	w.status = status // Store the status for our own use
+	w.ResponseWriter.WriteHeader(status)
+}
+
 // httpFileServer servers files from a specified folder
 // TODO if port can't be opened is not handled
 func httpFileServer(path string) *http.Server {
-	server := &http.Server{Addr: ":" + httpPort}
+	server := &http.Server{Addr: ":" + httpPort, Handler: logRequest(http.DefaultServeMux)}
 	http.Handle("/", http.FileServer(http.Dir(path)))
 	go func() {
 		server.ListenAndServe()
@@ -20,4 +30,17 @@ func httpFileServer(path string) *http.Server {
 	time.Sleep(100 * time.Millisecond) // It takes some time to open the port, just to be sure we wait a bit
 	logger.Infof("Server listening on port %s", httpPort)
 	return server
+}
+
+func logRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.Debugf("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
+		srw := &StatusRespWr{ResponseWriter: w}
+		handler.ServeHTTP(srw, r)
+		if srw.status >= 400 { // 400+ codes are the error codes
+			logger.Debugf("Error status code: %d when serving path: %s",
+				srw.status, r.RequestURI)
+		}
+
+	})
 }

--- a/utils.go
+++ b/utils.go
@@ -66,7 +66,7 @@ func untar(imageReader io.ReadCloser, target string) error {
 		}
 
 		path := filepath.Join(target, header.Name)
-		if !strings.HasPrefix(path, filepath.Clean(target) + string(os.PathSeparator)) {
+		if !strings.HasPrefix(path, filepath.Clean(target)+string(os.PathSeparator)) {
 			return fmt.Errorf("%s: illegal file path", header.Name)
 		}
 		info := header.FileInfo()
@@ -111,4 +111,12 @@ func validateThreshold(threshold string) {
 		}
 	}
 	logger.Fatalf("Invalid CVE severity threshold %s given", threshold)
+}
+
+func getEnv(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
 }


### PR DESCRIPTION
Since Docker 24.1.x image export is done in OCI format which is not supported by the clair-local-scan image which bundles an old CLAIR version.

It requires you to have [skopeo](https://github.com/containers/skopeo) binary somewhere in your system and the this tool has a recent version. If skopeo is not in the PATH, use SKOPEO_BIN_PATH environment variable to point to the executable.

Skopeo is used to transform the docker image to legacy format.

Dev has been tested with old and new Docker versions.

