### PR TITLE
Add "CGO_ENABLED=0" to build and release workflow

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -40,7 +40,7 @@ jobs:
           mkdir -p dist
           output_name=clair-scanner_${GOOS}-${GOARCH}
           [ "$GOOS" = "windows" ] && output_name+=".exe"
-          go build -o dist/$output_name
+          CGO_ENABLED=0 go build -o dist/$output_name
 
       # Step 5: Upload binaries as artifacts for inspection
       - name: Upload binaries


### PR DESCRIPTION
This addresses a bug when trying to use the current release on alpine linux on x86-64.
While debugging an issue with using the release on alpine linux I ran the ldd command:
```
ldd /usr/local/bin/clair-scanner 
	/lib64/ld-linux-x86-64.so.2 (0x773b6b9a7000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x773b6b9a7000)
Error relocating /usr/local/bin/clair-scanner: __vfprintf_chk: symbol not found
Error relocating /usr/local/bin/clair-scanner: __fprintf_chk: symbol not found
```

I did not see the issue with the arm64 version. Probably because it is cross compiled, and will does static linking instead
ldd output from the arm64 file:
```
ldd /usr/local/bin/clair-scanner 
/lib/ld-musl-aarch64.so.1: /usr/local/bin/clair-scanner: Not a valid dynamic program
```

Adding the `CGO_ENABLED=0` to the build command should force it to do a static build and fix it for alpine linux users.
The Makefile passes the `CGO_ENABLED=0` when building.

Downloading from the build from my fork results in what I would expect:
```
curl -SLo /usr/local/bin/clair-scanner https://github.com/notxarb/clair-scanner/releases/download/alpine-com
pat/clair-scanner_linux-amd64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 12.4M  100 12.4M    0     0  7180k      0  0:00:01  0:00:01 --:--:-- 13.1M
ldd /usr/local/bin/clair-scanner
/lib/ld-musl-x86_64.so.1: /usr/local/bin/clair-scanner: Not a valid dynamic program
```